### PR TITLE
reset ws connection

### DIFF
--- a/ape.go
+++ b/ape.go
@@ -3,6 +3,7 @@ package ape
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -135,6 +136,7 @@ func NewConnection(token string) *Connection {
 }
 
 func (con *Connection) Loop() {
+L:
 	ws, err := con.newWSConnection()
 	if err != nil {
 		panic(err)
@@ -142,7 +144,11 @@ func (con *Connection) Loop() {
 
 	for {
 		var data map[string]interface{}
-		websocket.JSON.Receive(ws, &data)
+		if err := websocket.JSON.Receive(ws, &data); err != nil {
+			log.Println("Receive failed. Conn will be reset. cause:", err)
+			ws.Close()
+			goto L
+		}
 		switch data["type"] {
 		case "hello":
 			e := newEvent(data)

--- a/ape.go
+++ b/ape.go
@@ -205,6 +205,7 @@ func (con *Connection) newWSConnection() (*websocket.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	con.userId = r.Self.Id
 	con.userName = r.Self.Name

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/shogo82148/ape-slack
+
+go 1.12
+
+require golang.org/x/net v0.0.0-20190724013045-ca1201d0de80

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=
+golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
websocket connection が切れた場合に ape-slack が暴走してしまいます。

`websocket.JSON.Receive()` のエラーをチェックし、 err != nil の場合にはコネクションを張り直します。

```
[root@dev-kuwata ~]# netstat -atpln | grep [g]opher
tcp        0      0 127.0.0.1:34823             0.0.0.0:*                   LISTEN      31355/gopher        
tcp        0      0 10.206.255.214:57698        xxxxx:443           CLOSE_WAIT  31355/gopher 
```